### PR TITLE
Nav menus - multiple calls to hasWorkflowAccess

### DIFF
--- a/src/main/config/portal/default/default/scripts/display/default/detail/navigation.py
+++ b/src/main/config/portal/default/default/scripts/display/default/detail/navigation.py
@@ -60,7 +60,9 @@ class NavigationData:
         return oid[0]
 
     def getObject(self):
-        if self.object is None:
+        if self.object:
+            return self.object
+        else:
             if self.metadata is not None:
                 oid = self.getOid()
                 if oid is not None:


### PR DESCRIPTION
When there was more than one menu item in the templates which checked hasWorkflowAccess, it was always failing on second and subsequent calls, even if the first call succeeded.

Traced this to a bug in the getObject method - if the self.object variable had already been set, it was returning None (rather than self.object).